### PR TITLE
make asm print labels as `:label ; offset = xx`

### DIFF
--- a/High_level_prototypes/asm.c
+++ b/High_level_prototypes/asm.c
@@ -621,7 +621,7 @@ void print_text(struct Token* p)
 	}
 	else if(':' == p->Text[0])
 	{
-		fprintf(stdout, " %x", p->address);
+		fprintf(stdout, " ; offset = %x", p->address);
 	}
 
 	if((NULL != p->next) && !((p->type & EOL)))


### PR DESCRIPTION
As the tests under `test_stage0_monitor_asm_match` in the makefile will break if the offsets after the labels in `stage0/stage0_monitor.hex0` are not commented, it makes sense to make asm print these offsets as a comment.