### PR TITLE
fix various things

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,7 +122,7 @@ Generate-rom-test: ALL-ROMS
 	mkdir -p test
 	sha256sum roms/* | sort -k2 >| test/SHA256SUMS
 
-test_stage0_monitor_asm_match: asm stage0_monitor
+test_stage0_monitor_asm_match: asm hex stage0_monitor
 	mkdir -p test/stage0_test_scratch
 	sed 's/^[^#]*# //' stage0/stage0_monitor.hex0 > test/stage0_test_scratch/stage0_monitor.hex0.s
 	bin/asm test/stage0_test_scratch/stage0_monitor.hex0.s > test/stage0_test_scratch/stage0_monitor.hex0.hex0
@@ -136,8 +136,8 @@ test_stage0_monitor_asm_match: asm stage0_monitor
 
 .SILENT: testM0
 .PHONY: testM0
-testM0: vm16 vm vm64 M0-compact prototypes/prototype_M0-macro-compact ALL-ROMS
-	echo assembling ALL-ROMS with prototype_M0-macro-compact and M0 with 32 bit vm and M0-compact with vm, vm64 and vm16; \
+testM0: vm16 vm vm64 M0-compact prototype_M0-compact ALL-ROMS
+	echo assembling ALL-ROMS with prototype_M0-compact and M0 with 32 bit vm and M0-compact with vm, vm64 and vm16; \
 	VM_LIST='vm vm64 vm16'; \
 	STAGE_1_UNIFORM_PROG_LIST="stage1_assembler-0 stage1_assembler-1 \
 stage1_assembler-2 CAT SET"; \
@@ -153,7 +153,7 @@ stage1/M0-macro stage1/M0-macro-compact stage1/dehex"; \
 	done; \
 	for prog in $$ASSEMBLER_PROG_LIST; do \
 	cat High_level_prototypes/defs "$$prog".s > "$$prog"_TEMP.s; \
-	./prototypes/prototype_M0-macro-compact "$$prog"_TEMP.s > \
+	./prototypes/prototype_M0-compact "$$prog"_TEMP.s > \
 	"$$prog"_protoM0compact_TEMP.hex2; \
 	./bin/vm --memory 256K --rom roms/stage1_assembler-2 \
 	    --tape_01 "$$prog"_protoM0compact_TEMP.hex2 \

--- a/makefile
+++ b/makefile
@@ -29,13 +29,13 @@ vm-minimal: vm.h vm_minimal.c vm_instructions.c vm_decode.c functions/require.c 
 	$(CC) -DVM32=true vm_minimal.c vm_instructions.c vm_decode.c functions/require.c functions/file_print.c functions/match.c -o bin/vm-minimal
 
 vm16: vm.h vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c | bin
-	$(CC) -ggdb -DVM16=true -Dtty_lib=true vm.h vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c -o bin/vm16
+	$(CC) -ggdb -DVM16=true -Dtty_lib=true vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c -o bin/vm16
 
 vm: vm.h vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c | bin
 	$(CC) -ggdb -DVM32=true -Dtty_lib=true vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c -o bin/vm
 
 vm64: vm.h vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c | bin
-	$(CC) -ggdb -DVM64=true -Dtty_lib=true vm.h vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c -o bin/vm64
+	$(CC) -ggdb -DVM64=true -Dtty_lib=true vm.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c functions/match.c -o bin/vm64
 
 vm-production: vm.h vm.c vm_instructions.c vm_decode.c functions/require.c functions/file_print.c functions/match.c | bin
 	$(CC) -DVM32=true vm.c vm_instructions.c vm_decode.c functions/require.c functions/file_print.c functions/match.c -o bin/vm-production
@@ -112,10 +112,10 @@ xeh: Linux\ Bootstrap/Legacy_pieces/xeh.c | bin
 
 # libVM Builds for Development tools
 libvm.so: wrapper.c vm_instructions.c vm_decode.c vm.h tty.c
-	$(CC) -ggdb -DVM32=true -Dtty_lib=true -shared -Wl,-soname,libvm.so -o libvm.so -fPIC wrapper.c vm_instructions.c vm_decode.c tty.c
+	$(CC) -ggdb -DVM32=true -Dtty_lib=true -shared -Wl,-soname,libvm.so -o libvm.so -fPIC wrapper.c vm_instructions.c vm_decode.c tty.c functions/require.c functions/file_print.c
 
 libvm-production.so: wrapper.c vm_instructions.c vm_decode.c vm.h
-	$(CC) -DVM32=true -shared -Wl,-soname,libvm.so -o libvm-production.so -fPIC wrapper.c vm_instructions.c vm_decode.c
+	$(CC) -DVM32=true -shared -Wl,-soname,libvm.so -o libvm-production.so -fPIC wrapper.c vm_instructions.c vm_decode.c functions/require.c functions/file_print.c
 
 # Tests
 Generate-rom-test: ALL-ROMS

--- a/stage2/High_level_prototypes/lisp/lisp.c
+++ b/stage2/High_level_prototypes/lisp/lisp.c
@@ -15,6 +15,7 @@
  * along with stage0.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define LISP_H__VAR_DEF
 #include "lisp.h"
 #include <stdint.h>
 

--- a/stage2/High_level_prototypes/lisp/lisp.h
+++ b/stage2/High_level_prototypes/lisp/lisp.h
@@ -55,17 +55,24 @@ typedef struct cell
 
 struct cell* make_cons(struct cell* a, struct cell* b);
 
+
+/* Avoid redefinition. Must be already defined in only one .c*/
+#ifndef LISP_H__VAR_DEF
+#define LISP_H__VAR_DEF extern
+#endif
+
+
 /* Global objects */
-struct cell *all_symbols;
-struct cell *top_env;
-struct cell *nil;
-struct cell *tee;
-struct cell *quote;
-struct cell *s_if;
-struct cell *s_lambda;
-struct cell *s_define;
-struct cell *s_setb;
-struct cell *s_cond;
-struct cell *s_begin;
-struct cell *s_let;
-FILE* output;
+LISP_H__VAR_DEF struct cell *all_symbols;
+LISP_H__VAR_DEF struct cell *top_env;
+LISP_H__VAR_DEF struct cell *nil;
+LISP_H__VAR_DEF struct cell *tee;
+LISP_H__VAR_DEF struct cell *quote;
+LISP_H__VAR_DEF struct cell *s_if;
+LISP_H__VAR_DEF struct cell *s_lambda;
+LISP_H__VAR_DEF struct cell *s_define;
+LISP_H__VAR_DEF struct cell *s_setb;
+LISP_H__VAR_DEF struct cell *s_cond;
+LISP_H__VAR_DEF struct cell *s_begin;
+LISP_H__VAR_DEF struct cell *s_let;
+LISP_H__VAR_DEF FILE* output;

--- a/vm.c
+++ b/vm.c
@@ -15,7 +15,6 @@
  * along with stage0.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define VM_H__VAR_DEF
 #include "vm.h"
 #include <getopt.h>
 

--- a/vm.c
+++ b/vm.c
@@ -15,6 +15,7 @@
  * along with stage0.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define VM_H__VAR_DEF
 #include "vm.h"
 #include <getopt.h>
 

--- a/vm.h
+++ b/vm.h
@@ -316,13 +316,18 @@ void read_instruction(struct lilith* vm, struct Instruction *current);
 void eval_instruction(struct lilith* vm, struct Instruction* current);
 void outside_of_world(struct lilith* vm, unsigned_vm_register place, char* message);
 
+/* Avoid redefinition. Must be already defined in only one .c*/
+#ifndef VM_H__VAR_DEF
+#define VM_H__VAR_DEF extern
+#endif
+
 /* Allow tape names to be effectively changed */
-char* tape_01_name;
-char* tape_02_name;
+VM_H__VAR_DEF char* tape_01_name;
+VM_H__VAR_DEF char* tape_02_name;
 
 /* Enable POSIX Mode */
-bool POSIX_MODE;
-bool FUZZING;
+VM_H__VAR_DEF bool POSIX_MODE;
+VM_H__VAR_DEF bool FUZZING;
 
 /* Commonly useful functions */
 void require(int boolean, char* error);

--- a/vm_instructions.c
+++ b/vm_instructions.c
@@ -15,6 +15,7 @@
  * along with stage0.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define VM_H__VAR_DEF
 #include "vm.h"
 #include <unistd.h>
 #include <sys/stat.h>

--- a/vm_instructions.c
+++ b/vm_instructions.c
@@ -27,19 +27,7 @@ char tty_getchar();
 #endif
 
 /* Define the value needed to split the result so that it fits the register size. */
-#ifdef VM256
-#define VM_SIZE 256
-#elif VM128
-#define VM_SIZE 128
-#elif VM64
-#define VM_SIZE 64
-#elif VM32
-#define VM_SIZE 32
-#else
-#define VM_SIZE 16
-#endif
-
-#define TO_SPLIT_REGS (((signed_wide_register) 1) << VM_SIZE)
+#define TO_SPLIT_REGS (((signed_wide_register) 1) << umax)
 
 
 /* Use first byte of next instruction to identify size */

--- a/vm_instructions.c
+++ b/vm_instructions.c
@@ -26,6 +26,22 @@ FILE* tape_02;
 char tty_getchar();
 #endif
 
+/* Define the value needed to split the result so that it fits the register size. */
+#ifdef VM256
+#define VM_SIZE 256
+#elif VM128
+#define VM_SIZE 128
+#elif VM64
+#define VM_SIZE 64
+#elif VM32
+#define VM_SIZE 32
+#else
+#define VM_SIZE 16
+#endif
+
+#define TO_SPLIT_REGS (((signed_wide_register) 1) << VM_SIZE)
+
+
 /* Use first byte of next instruction to identify size */
 int next_instruction_size(struct lilith* vm)
 {
@@ -121,7 +137,7 @@ unsigned_vm_register shift_register(unsigned_vm_register source, unsigned_vm_reg
 			amount = amount - 1;
 			if(!zero)
 			{
-				tmp = tmp | (1 << imax);
+				tmp = tmp | (((unsigned_vm_register) 1) << imax);
 			}
 		}
 	}
@@ -762,22 +778,8 @@ void MULTIPLY(struct lilith* vm, struct Instruction* c)
 	tmp2 = (signed_vm_register)( vm->reg[c->reg3]);
 	btmp1 = ((signed_wide_register)tmp1) * ((signed_wide_register)tmp2);
 
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % 0x10000000000000000000000000000000000000000000000000000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % 0x100000000000000000000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % 0x10000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % 0x100000000);
-	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % 0x10000);
-	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(btmp1 % TO_SPLIT_REGS);
+	vm->reg[c->reg1] = (signed_vm_register)(btmp1 / TO_SPLIT_REGS);
 }
 
 void MULTIPLYU(struct lilith* vm, struct Instruction* c)
@@ -785,22 +787,8 @@ void MULTIPLYU(struct lilith* vm, struct Instruction* c)
 	unsigned_wide_register ubtmp1;
 
 	ubtmp1 = (unsigned_wide_register)(vm->reg[c->reg2]) * (unsigned_wide_register)(vm->reg[c->reg3]);
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % 0x10000000000000000000000000000000000000000000000000000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % 0x100000000000000000000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % 0x10000000000000000);
-	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % 0x100000000);
-	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % 0x10000);
-	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(ubtmp1 % TO_SPLIT_REGS);
+	vm->reg[c->reg1] = (signed_vm_register)(ubtmp1 / TO_SPLIT_REGS);
 }
 
 void DIVIDE(struct lilith* vm, struct Instruction* c)
@@ -955,19 +943,8 @@ void MUL(struct lilith* vm, struct Instruction* c)
 
 	signed_wide_register sum = tmp1 * tmp2;
 
-
 	/* We only want the bottom half of the bits */
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(sum % TO_SPLIT_REGS);
 }
 
 void MULH(struct lilith* vm, struct Instruction* c)
@@ -980,17 +957,7 @@ void MULH(struct lilith* vm, struct Instruction* c)
 	signed_wide_register sum = tmp1 * tmp2;
 
 	/* We only want the top half of the bits */
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(sum / TO_SPLIT_REGS);
 }
 
 void MULU(struct lilith* vm, struct Instruction* c)
@@ -1002,17 +969,7 @@ void MULU(struct lilith* vm, struct Instruction* c)
 	sum = tmp1 * tmp2;
 
 	/* We only want the bottom half of the bits */
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(sum % 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(sum % TO_SPLIT_REGS);
 }
 
 void MULUH(struct lilith* vm, struct Instruction* c)
@@ -1024,17 +981,7 @@ void MULUH(struct lilith* vm, struct Instruction* c)
 	sum = tmp1 * tmp2;
 
 	/* We only want the top half of the bits */
-#ifdef VM256
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000000000000000000000000000000000000000000000000000000000000000);
-#elif VM128
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x100000000000000000000000000000000);
-#elif VM64
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000000000000000);
-#elif VM32
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x100000000);
-#else
-	vm->reg[c->reg0] = (signed_vm_register)(sum / 0x10000);
-#endif
+	vm->reg[c->reg0] = (signed_vm_register)(sum / TO_SPLIT_REGS);
 }
 
 void DIV(struct lilith* vm, struct Instruction* c)
@@ -1218,7 +1165,7 @@ void ROL(struct lilith* vm, struct Instruction* c)
 	for(i = vm->reg[c->reg2]; i > 0; i = i - 1)
 	{
 		bit = (tmp & 1);
-		tmp = (tmp / 2) + (bit << imax);
+		tmp = (tmp / 2) + (((unsigned_vm_register) bit) << imax);
 	}
 
 	vm->reg[c->reg0] = tmp;
@@ -1417,17 +1364,7 @@ void FALSE(struct lilith* vm, struct Instruction* c)
 
 void TRUE(struct lilith* vm, struct Instruction* c)
 {
-#ifdef VM256
-	vm->reg[c->reg0] = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-#elif VM128
-	vm->reg[c->reg0] = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-#elif VM64
-	vm->reg[c->reg0] = 0xFFFFFFFFFFFFFFFF;
-#elif VM32
-	vm->reg[c->reg0] = 0xFFFFFFFF;
-#else
-	vm->reg[c->reg0] = 0xFFFF;
-#endif
+	vm->reg[c->reg0] = TO_SPLIT_REGS -1;
 }
 
 void JSR_COROUTINE(struct lilith* vm, struct Instruction* c)

--- a/wrapper.c
+++ b/wrapper.c
@@ -17,7 +17,7 @@
 
 #include "vm.h"
 #define DEBUG true
-uint32_t performance_counter;
+extern uint32_t performance_counter;
 static struct lilith* Globalvm;
 
 void unpack_byte(uint8_t a, char* c);


### PR DESCRIPTION
It seems your compiler/linker doesn't complain about duplicate definitions, because I cloned the repo, run 'make development' and it failed with ld complaining that the same variables from vm.h have been defined in multiple .o (that gcc created internally from the .c). I'm using gcc 10.2 in debian sid.

This is a simple fix, where I tried to avoid duplicating the declaration and the definition. I used a define before the import to parametrize the vm.h, so that only the vm.c defines those variables. After this 'make development' and 'make test' both work.