### PR TITLE
Add support for anonymous enums

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,7 +44,7 @@ vm-trace: vm.h vm_types.h vm_globals.c vm.c vm_instructions.c vm_halcode.c vm_de
 	$(CC) -DVM32=true -ggdb -Dtty_lib=true -DTRACE=true vm.c vm_globals.c vm_instructions.c vm_halcode.c vm_decode.c tty.c dynamic_execution_trace.c functions/require.c functions/file_print.c functions/match.c -o bin/vm
 
 # Build the roms
-ALL-ROMS: stage0_monitor stage1_assembler-0 SET DEHEX stage1_assembler-1 stage1_assembler-2 M0 CAT lisp cc_x86 forth
+ALL-ROMS: stage0_monitor stage1_assembler-0 SET DEHEX stage1_assembler-1 stage1_assembler-2 M0 CAT lisp cc_x86 cc_aarch64 cc_amd64 cc_armv7l cc_knight-posix cc_knight-native forth
 
 stage0_monitor: vm stage0/stage0_monitor.hex0 | roms
 	./bin/vm --rom seed/NATIVE/knight/hex0-seed --tape_01 stage0/stage0_monitor.hex0 --tape_02 roms/stage0_monitor
@@ -85,10 +85,40 @@ lisp: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/lisp.s 
 	./bin/vm --rom roms/stage1_assembler-2 --tape_01 lisp_TEMP2 --tape_02 roms/lisp --memory 48K
 	rm lisp_TEMP lisp_TEMP2
 
+cc_aarch64: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_aarch64.s | roms
+	cat High_level_prototypes/defs stage2/cc_aarch64.s > cc_TEMP
+	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
+	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_aarch64 --memory 32K
+	rm cc_TEMP cc_TEMP2
+
+cc_amd64: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_amd64.s | roms
+	cat High_level_prototypes/defs stage2/cc_amd64.s > cc_TEMP
+	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
+	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_amd64 --memory 32K
+	rm cc_TEMP cc_TEMP2
+
+cc_armv7l: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_armv7l.s | roms
+	cat High_level_prototypes/defs stage2/cc_armv7l.s > cc_TEMP
+	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
+	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_armv7l --memory 32K
+	rm cc_TEMP cc_TEMP2
+
 cc_x86: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_x86.s | roms
 	cat High_level_prototypes/defs stage2/cc_x86.s > cc_TEMP
 	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
 	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_x86 --memory 32K
+	rm cc_TEMP cc_TEMP2
+
+cc_knight-posix: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_knight-posix.s | roms
+	cat High_level_prototypes/defs stage2/cc_knight-posix.s > cc_TEMP
+	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
+	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_knight-posix --memory 32K
+	rm cc_TEMP cc_TEMP2
+
+cc_knight-native: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/cc_knight-native.s | roms
+	cat High_level_prototypes/defs stage2/cc_knight-native.s > cc_TEMP
+	./bin/vm --rom roms/M0-compact --tape_01 cc_TEMP --tape_02 cc_TEMP2 --memory 9K
+	./bin/vm --rom roms/stage1_assembler-2 --tape_01 cc_TEMP2 --tape_02 roms/cc_knight-native --memory 32K
 	rm cc_TEMP cc_TEMP2
 
 forth: M0-compact stage1_assembler-2 vm High_level_prototypes/defs stage2/forth.s | roms

--- a/stage2/High_level_prototypes/cc_aarch64/cc_core.c
+++ b/stage2/High_level_prototypes/cc_aarch64/cc_core.c
@@ -1096,7 +1096,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/High_level_prototypes/cc_amd64/cc_core.c
+++ b/stage2/High_level_prototypes/cc_amd64/cc_core.c
@@ -1089,7 +1089,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/High_level_prototypes/cc_armv7l/cc_core.c
+++ b/stage2/High_level_prototypes/cc_armv7l/cc_core.c
@@ -1095,7 +1095,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/High_level_prototypes/cc_knight-native/cc_core.c
+++ b/stage2/High_level_prototypes/cc_knight-native/cc_core.c
@@ -1097,7 +1097,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/High_level_prototypes/cc_knight-posix/cc_core.c
+++ b/stage2/High_level_prototypes/cc_knight-posix/cc_core.c
@@ -1097,7 +1097,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/High_level_prototypes/cc_x86/cc_core.c
+++ b/stage2/High_level_prototypes/cc_x86/cc_core.c
@@ -1089,7 +1089,32 @@ struct token_list* program()
 
 new_type:
 	if (NULL == global_token) return out;
-	if(match("CONSTANT", global_token->s))
+	if(match("enum", global_token->s))
+	{
+		global_token = global_token->next;
+		require_match("ERROR in enum\nExpected {\n", "{");
+
+		do
+		{
+			global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+			global_token = global_token->next;
+
+			require_match("ERROR in enum\nExpected =\n", "=");
+
+			global_constant_list->arguments = global_token;
+			global_token = global_token->next;
+
+			if(match(global_token->s, ","))
+			{
+				global_token = global_token->next;
+			}
+		}
+		while(!match(global_token->s, "}"));
+
+		require_match("ERROR in enum\nExpected }\n", "}");
+		require_match("ERROR in enum\nExpected ;\n", ";");
+	}
+	else if(match("CONSTANT", global_token->s))
 	{
 		global_token = global_token->next;
 		global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);

--- a/stage2/cc_aarch64.s
+++ b/stage2/cc_aarch64.s
@@ -3171,6 +3171,22 @@ Missing ;
 :current_count
 	NOP
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
 
 ;; program function
 ;; Receives struct token_list* global_token in R13,
@@ -3187,6 +3203,64 @@ Missing ;
 	PUSHR R2 R15                ; Protect R2
 	PUSHR R3 R15                ; Protect R3
 :program_iter
+	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
+	LOADUI R0 $enum             ; "enum"
+	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
+	CALLI R15 @match            ; Check if they match
+	JUMP.Z R0 @constant_value   ; Looks like not an enum
+
+	;; Deal with enum case
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_open_curly  ; Using "ERROR in enum\nExpected {"
+	LOADUI R1 $open_curly_brace       ; Checking for {
+	CALLI R15 @require_match          ; Require match and skip
+
+:enumerator
+	LOAD32 R0 R13 8                   ; GLOBAL_TOKEN->S
+	FALSE R1                          ; Set NULL
+	LOADR32 R2 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	CALLI R15 @sym_declare
+	STORER32 R0 @global_constant_list ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_equal       ; Using "ERROR in enum\nExpected ="
+	LOADUI R1 $equal                  ; Checking for =
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADR32 R0 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	STORE32 R13 R0 16                 ; GLOBAL_CONSTANT_LIST->ARGUMENTS = GLOBAL_TOKEN
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $comma                  ; ","
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enum_end               ; No comma means no more enumerators
+
+	;; Skip comma
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	;; Check if there are more enumerators or if it was a trailing comma
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $close_curly_brace      ; "}"
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enumerator               ; More enumerators
+
+:enum_end
+	LOADUI R0 $enum_error_close_curly ; Using "ERROR in enum\nExpected }"
+	LOADUI R1 $close_curly_brace      ; Checking for }
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADUI R0 $enum_error_semi_colon  ; Using "ERROR in enum\nExpected ;"
+	LOADUI R1 $semicolon              ; Checking for ;
+	CALLI R15 @require_match          ; Require match and skip
+
+	JUMP @program_iter                ; Loop again
+
+:constant_value
 	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
 	LOADUI R0 $constant         ; Using the constant string
 	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
@@ -4192,6 +4266,8 @@ Missing ;
 	"union"
 :struct
 	"struct"
+:enum
+	"enum"
 :constant
 	"CONSTANT"
 :main_string
@@ -4276,6 +4352,8 @@ Missing ;
 	"["
 :close_bracket
 	"]"
+:comma
+	","
 :semicolon
 	";"
 :equal

--- a/stage2/cc_armv7l.s
+++ b/stage2/cc_armv7l.s
@@ -3123,6 +3123,22 @@ Missing ;
 :current_count
 	NOP
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
 
 ;; program function
 ;; Receives struct token_list* global_token in R13,
@@ -3139,6 +3155,64 @@ Missing ;
 	PUSHR R2 R15                ; Protect R2
 	PUSHR R3 R15                ; Protect R3
 :program_iter
+	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
+	LOADUI R0 $enum             ; "enum"
+	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
+	CALLI R15 @match            ; Check if they match
+	JUMP.Z R0 @constant_value   ; Looks like not an enum
+
+	;; Deal with enum case
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_open_curly  ; Using "ERROR in enum\nExpected {"
+	LOADUI R1 $open_curly_brace       ; Checking for {
+	CALLI R15 @require_match          ; Require match and skip
+
+:enumerator
+	LOAD32 R0 R13 8                   ; GLOBAL_TOKEN->S
+	FALSE R1                          ; Set NULL
+	LOADR32 R2 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	CALLI R15 @sym_declare
+	STORER32 R0 @global_constant_list ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_equal       ; Using "ERROR in enum\nExpected ="
+	LOADUI R1 $equal                  ; Checking for =
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADR32 R0 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	STORE32 R13 R0 16                 ; GLOBAL_CONSTANT_LIST->ARGUMENTS = GLOBAL_TOKEN
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $comma                  ; ","
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enum_end               ; No comma means no more enumerators
+
+	;; Skip comma
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	;; Check if there are more enumerators or if it was a trailing comma
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $close_curly_brace      ; "}"
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enumerator               ; More enumerators
+
+:enum_end
+	LOADUI R0 $enum_error_close_curly ; Using "ERROR in enum\nExpected }"
+	LOADUI R1 $close_curly_brace      ; Checking for }
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADUI R0 $enum_error_semi_colon  ; Using "ERROR in enum\nExpected ;"
+	LOADUI R1 $semicolon              ; Checking for ;
+	CALLI R15 @require_match          ; Require match and skip
+
+	JUMP @program_iter                ; Loop again
+
+:constant_value
 	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
 	LOADUI R0 $constant         ; Using the constant string
 	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
@@ -4138,6 +4212,8 @@ Missing ;
 	"union"
 :struct
 	"struct"
+:enum
+	"enum"
 :constant
 	"CONSTANT"
 :main_string
@@ -4222,6 +4298,8 @@ Missing ;
 	"["
 :close_bracket
 	"]"
+:comma
+	","
 :semicolon
 	";"
 :equal

--- a/stage2/cc_knight-native.s
+++ b/stage2/cc_knight-native.s
@@ -3138,6 +3138,22 @@ Missing ;
 :current_count
 	NOP
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
 
 ;; program function
 ;; Receives struct token_list* global_token in R13,
@@ -3154,6 +3170,64 @@ Missing ;
 	PUSHR R2 R15                ; Protect R2
 	PUSHR R3 R15                ; Protect R3
 :program_iter
+	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
+	LOADUI R0 $enum             ; "enum"
+	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
+	CALLI R15 @match            ; Check if they match
+	JUMP.Z R0 @constant_value   ; Looks like not an enum
+
+	;; Deal with enum case
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_open_curly  ; Using "ERROR in enum\nExpected {"
+	LOADUI R1 $open_curly_brace       ; Checking for {
+	CALLI R15 @require_match          ; Require match and skip
+
+:enumerator
+	LOAD32 R0 R13 8                   ; GLOBAL_TOKEN->S
+	FALSE R1                          ; Set NULL
+	LOADR32 R2 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	CALLI R15 @sym_declare
+	STORER32 R0 @global_constant_list ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_equal       ; Using "ERROR in enum\nExpected ="
+	LOADUI R1 $equal                  ; Checking for =
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADR32 R0 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	STORE32 R13 R0 16                 ; GLOBAL_CONSTANT_LIST->ARGUMENTS = GLOBAL_TOKEN
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $comma                  ; ","
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enum_end               ; No comma means no more enumerators
+
+	;; Skip comma
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	;; Check if there are more enumerators or if it was a trailing comma
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $close_curly_brace      ; "}"
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enumerator               ; More enumerators
+
+:enum_end
+	LOADUI R0 $enum_error_close_curly ; Using "ERROR in enum\nExpected }"
+	LOADUI R1 $close_curly_brace      ; Checking for }
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADUI R0 $enum_error_semi_colon  ; Using "ERROR in enum\nExpected ;"
+	LOADUI R1 $semicolon              ; Checking for ;
+	CALLI R15 @require_match          ; Require match and skip
+
+	JUMP @program_iter                ; Loop again
+
+:constant_value
 	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
 	LOADUI R0 $constant         ; Using the constant string
 	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
@@ -4152,6 +4226,8 @@ Missing ;
 	"union"
 :struct
 	"struct"
+:enum
+	"enum"
 :constant
 	"CONSTANT"
 :main_string
@@ -4236,6 +4312,8 @@ Missing ;
 	"["
 :close_bracket
 	"]"
+:comma
+	","
 :semicolon
 	";"
 :equal

--- a/stage2/cc_knight-posix.s
+++ b/stage2/cc_knight-posix.s
@@ -3137,6 +3137,22 @@ Missing ;
 :current_count
 	NOP
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
 
 ;; program function
 ;; Receives struct token_list* global_token in R13,
@@ -3153,6 +3169,64 @@ Missing ;
 	PUSHR R2 R15                ; Protect R2
 	PUSHR R3 R15                ; Protect R3
 :program_iter
+	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
+	LOADUI R0 $enum             ; "enum"
+	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
+	CALLI R15 @match            ; Check if they match
+	JUMP.Z R0 @constant_value   ; Looks like not an enum
+
+	;; Deal with enum case
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_open_curly  ; Using "ERROR in enum\nExpected {"
+	LOADUI R1 $open_curly_brace       ; Checking for {
+	CALLI R15 @require_match          ; Require match and skip
+
+:enumerator
+	LOAD32 R0 R13 8                   ; GLOBAL_TOKEN->S
+	FALSE R1                          ; Set NULL
+	LOADR32 R2 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	CALLI R15 @sym_declare
+	STORER32 R0 @global_constant_list ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_equal       ; Using "ERROR in enum\nExpected ="
+	LOADUI R1 $equal                  ; Checking for =
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADR32 R0 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	STORE32 R13 R0 16                 ; GLOBAL_CONSTANT_LIST->ARGUMENTS = GLOBAL_TOKEN
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $comma                  ; ","
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enum_end               ; No comma means no more enumerators
+
+	;; Skip comma
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	;; Check if there are more enumerators or if it was a trailing comma
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $close_curly_brace      ; "}"
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enumerator               ; More enumerators
+
+:enum_end
+	LOADUI R0 $enum_error_close_curly ; Using "ERROR in enum\nExpected }"
+	LOADUI R1 $close_curly_brace      ; Checking for }
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADUI R0 $enum_error_semi_colon  ; Using "ERROR in enum\nExpected ;"
+	LOADUI R1 $semicolon              ; Checking for ;
+	CALLI R15 @require_match          ; Require match and skip
+
+	JUMP @program_iter                ; Loop again
+
+:constant_value
 	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
 	LOADUI R0 $constant         ; Using the constant string
 	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
@@ -4151,6 +4225,8 @@ Missing ;
 	"union"
 :struct
 	"struct"
+:enum
+	"enum"
 :constant
 	"CONSTANT"
 :main_string
@@ -4235,6 +4311,8 @@ Missing ;
 	"["
 :close_bracket
 	"]"
+:comma
+	","
 :semicolon
 	";"
 :equal

--- a/stage2/cc_x86.s
+++ b/stage2/cc_x86.s
@@ -3096,6 +3096,22 @@ Missing ;
 :current_count
 	NOP
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
 
 ;; program function
 ;; Receives struct token_list* global_token in R13,
@@ -3113,6 +3129,65 @@ Missing ;
 	PUSHR R3 R15                ; Protect R3
 :program_iter
 	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
+	LOADUI R0 $enum             ; "enum"
+	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
+	CALLI R15 @match            ; Check if they match
+	JUMP.Z R0 @constant_value   ; Looks like not an enum
+
+	;; Deal with enum case
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_open_curly  ; Using "ERROR in enum\nExpected {"
+	LOADUI R1 $open_curly_brace       ; Checking for {
+	CALLI R15 @require_match          ; Require match and skip
+
+:enumerator
+	LOAD32 R0 R13 8                   ; GLOBAL_TOKEN->S
+	FALSE R1                          ; Set NULL
+	LOADR32 R2 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	CALLI R15 @sym_declare
+	STORER32 R0 @global_constant_list ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOADUI R0 $enum_error_equal       ; Using "ERROR in enum\nExpected ="
+	LOADUI R1 $equal                  ; Checking for =
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADR32 R0 @global_constant_list  ; GLOBAL_CONSTANTS_LIST
+	STORE32 R13 R0 16                 ; GLOBAL_CONSTANT_LIST->ARGUMENTS = GLOBAL_TOKEN
+
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $comma                  ; ","
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enum_end               ; No comma means no more enumerators
+
+	;; Skip comma
+	LOAD32 R13 R13 0                  ; GLOBAL_TOKEN = GLOBAL_TOKEN->NEXT
+
+	;; Check if there are more enumerators or if it was a trailing comma
+	LOAD32 R1 R13 8                   ; GLOBAL_TOKEN->S
+	LOADUI R0 $close_curly_brace      ; "}"
+	CALLI R15 @match                  ; Check if they match
+	JUMP.Z R0 @enumerator               ; More enumerators
+
+:enum_end
+	LOADUI R0 $enum_error_close_curly ; Using "ERROR in enum\nExpected }"
+	LOADUI R1 $close_curly_brace      ; Checking for }
+	CALLI R15 @require_match          ; Require match and skip
+
+	LOADUI R0 $enum_error_semi_colon  ; Using "ERROR in enum\nExpected ;"
+	LOADUI R1 $semicolon              ; Checking for ;
+	CALLI R15 @require_match          ; Require match and skip
+
+	JUMP @program_iter                ; Loop again
+
+:constant_value
+	JUMP.Z R13 @program_done    ; Looks like we read all the tokens
+
 	LOADUI R0 $constant         ; Using the constant string
 	LOAD32 R1 R13 8             ; GLOBAL_TOKEN->S
 	CALLI R15 @match            ; Check if they match
@@ -4105,6 +4180,8 @@ Missing ;
 	"union"
 :struct
 	"struct"
+:enum
+	"enum"
 :constant
 	"CONSTANT"
 :main_string
@@ -4189,6 +4266,8 @@ Missing ;
 	"["
 :close_bracket
 	"]"
+:comma
+	","
 :semicolon
 	";"
 :equal


### PR DESCRIPTION
@stikonas @oriansj

This is a copy paste job since they all share the same mnemonics. I also had to add the other `cc_*`s to the makefile to test them. I just left it in since I'm assuming that they are supposed to be built.

Test file:
```c
// CONSTANT TEST5 5
enum {
    TEST1 = 1,
    TEST2 = 2
};

enum {
    TEST3 = 3,
    TEST4 = 4,
};

int main() {
    return TEST1 + TEST2 + TEST3 + TEST4 + TEST5;
}
```

aarch64 output:
```
:FUNCTION_main
LOAD_W0_AHEAD
SKIP_32_DATA
%1
PUSH_X0	#_common_recursion
LOAD_W0_AHEAD
SKIP_32_DATA
%2
POP_X1	# _common_recursion
ADD_X0_X1_X0
PUSH_X0	#_common_recursion
LOAD_W0_AHEAD
SKIP_32_DATA
%3
POP_X1	# _common_recursion
ADD_X0_X1_X0
PUSH_X0	#_common_recursion
LOAD_W0_AHEAD
SKIP_32_DATA
%4
POP_X1	# _common_recursion
ADD_X0_X1_X0
PUSH_X0	#_common_recursion
LOAD_W0_AHEAD
SKIP_32_DATA
%5
POP_X1	# _common_recursion
ADD_X0_X1_X0
RETURN

:ELF_end
```

amd64 output:
```
:FUNCTION_main
LOAD_IMMEDIATE_rax %1
PUSH_RAX	#_common_recursion
LOAD_IMMEDIATE_rax %2
POP_RBX	# _common_recursion
ADD_rbx_to_rax
PUSH_RAX	#_common_recursion
LOAD_IMMEDIATE_rax %3
POP_RBX	# _common_recursion
ADD_rbx_to_rax
PUSH_RAX	#_common_recursion
LOAD_IMMEDIATE_rax %4
POP_RBX	# _common_recursion
ADD_rbx_to_rax
PUSH_RAX	#_common_recursion
LOAD_IMMEDIATE_rax %5
POP_RBX	# _common_recursion
ADD_rbx_to_rax
RETURN

:ELF_end
```

armv7l output:
```
:FUNCTION_main
!0 R0 LOAD32 R15 MEMORY
~0 JUMP_ALWAYS
%1
{R0} PUSH_ALWAYS	#_common_recursion
!0 R0 LOAD32 R15 MEMORY
~0 JUMP_ALWAYS
%2
{R1} POP_ALWAYS	# _common_recursion
'0' R0 R0 ADD R1 ARITH2_ALWAYS
{R0} PUSH_ALWAYS	#_common_recursion
!0 R0 LOAD32 R15 MEMORY
~0 JUMP_ALWAYS
%3
{R1} POP_ALWAYS	# _common_recursion
'0' R0 R0 ADD R1 ARITH2_ALWAYS
{R0} PUSH_ALWAYS	#_common_recursion
!0 R0 LOAD32 R15 MEMORY
~0 JUMP_ALWAYS
%4
{R1} POP_ALWAYS	# _common_recursion
'0' R0 R0 ADD R1 ARITH2_ALWAYS
{R0} PUSH_ALWAYS	#_common_recursion
!0 R0 LOAD32 R15 MEMORY
~0 JUMP_ALWAYS
%5
{R1} POP_ALWAYS	# _common_recursion
'0' R0 R0 ADD R1 ARITH2_ALWAYS
'1' LR RETURN

:ELF_end
```

x86 output:
```
:FUNCTION_main
LOAD_IMMEDIATE_eax %1
PUSH_eax	#_common_recursion
LOAD_IMMEDIATE_eax %2
POP_ebx	# _common_recursion
ADD_ebx_to_eax
PUSH_eax	#_common_recursion
LOAD_IMMEDIATE_eax %3
POP_ebx	# _common_recursion
ADD_ebx_to_eax
PUSH_eax	#_common_recursion
LOAD_IMMEDIATE_eax %4
POP_ebx	# _common_recursion
ADD_ebx_to_eax
PUSH_eax	#_common_recursion
LOAD_IMMEDIATE_eax %5
POP_ebx	# _common_recursion
ADD_ebx_to_eax
RETURN

:ELF_end
```

knight-posix:
```

:FUNCTION_main
LOADI R0 1
PUSHR R0 R15	#_common_recursion
LOADI R0 2
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 3
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 4
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 5
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
RET R15

:ELF_end
```

knight-native:
```

:FUNCTION_main
LOADI R0 1
PUSHR R0 R15	#_common_recursion
LOADI R0 2
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 3
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 4
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
PUSHR R0 R15	#_common_recursion
LOADI R0 5
POPR R1 R15	# _common_recursion
ADD R0 R1 R0
RET R15

:STACK
```